### PR TITLE
feat/16: navigation with parameter 구현

### DIFF
--- a/lib/core/di/injector.dart
+++ b/lib/core/di/injector.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/presentation/game_play/game_play_view_model.dart';
 import 'package:run_or_not/presentation/home/home_view_model.dart';
 import 'package:run_or_not/presentation/ranking/ranking_view_model.dart';
@@ -15,6 +16,8 @@ void setupDependencies() {
   getIt.registerSingleton<RouterService>(RouterServiceImpl(router));
 
   getIt.registerFactory<HomeViewModel>(() => HomeViewModel(getIt<RouterService>()));
-  getIt.registerFactory<GamePlayViewModel>(() => GamePlayViewModel(getIt<RouterService>()));
+  getIt.registerFactoryParam<GamePlayViewModel, List<CustomCharacter>, void>(
+    (characters, _) => GamePlayViewModel(getIt<RouterService>(), characters),
+  );
   getIt.registerFactory(() => RankingViewModel());
 }

--- a/lib/presentation/game_play/game_play_state.dart
+++ b/lib/presentation/game_play/game_play_state.dart
@@ -1,14 +1,21 @@
+import 'package:run_or_not/domain/model/character/custom_character.dart';
+
 class GamePlayState {
   final int count;
+  final List<CustomCharacter> characters;
+
   GamePlayState({
-    this.count = 0
+    this.count = 0,
+    required this.characters,
   });
 
   GamePlayState copyWith({
-    int? count
+    int? count,
+    List<CustomCharacter>? characters,
   }) {
     return GamePlayState(
-        count: count ?? this.count
+        count: count ?? this.count,
+        characters: characters ?? this.characters,
     );
   }
 }

--- a/lib/presentation/game_play/game_play_view.dart
+++ b/lib/presentation/game_play/game_play_view.dart
@@ -11,14 +11,35 @@ class GamePlayView extends StatelessWidget {
     final _viewModel = context.read<GamePlayViewModel>();
 
     return Scaffold(
-      appBar: AppBar(title: const Text('GamePlay View')),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () {
-            _viewModel.send(GoBackButtonTapped());
-          },
-          child: const Text('Go Back'),
-        ),
+      // appBar: AppBar(title: const Text('GamePlay View')),
+      body: Column(
+        children: [
+          Center(
+            child: ElevatedButton(
+              onPressed: () {
+                _viewModel.send(GoBackButtonTapped());
+              },
+              child: const Text('Go Back'),
+            ),
+          ),
+
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: _viewModel.state.characters.map((character) {
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(16),
+                  color: Color(character.hexColor),
+                  child: Text(
+                    character.name,
+                    style: const TextStyle(fontSize: 18, color: Colors.white),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/game_play/game_play_view_model.dart
+++ b/lib/presentation/game_play/game_play_view_model.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/presentation/game_play/game_play_intent.dart';
 import 'package:run_or_not/presentation/game_play/game_play_state.dart';
 import 'package:run_or_not/presentation/router/service/router_service.dart';
 
 class GamePlayViewModel extends ChangeNotifier {
   final RouterService _routerService;
-
-  GamePlayViewModel(this._routerService);
-
-  GamePlayState _state = GamePlayState();
+  GamePlayState _state;
   GamePlayState get state => _state;
+
+  GamePlayViewModel(
+      this._routerService,
+      List<CustomCharacter> characters,
+  ): _state = GamePlayState(characters: characters);
 
   Future<void> send(GamePlayIntent intent) async {
     final newState = reduce(_state, intent);

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:run_or_not/core/di/injector.dart';
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/presentation/game_play/game_play_view.dart';
 import 'package:run_or_not/presentation/game_play/game_play_view_model.dart';
 import 'package:run_or_not/presentation/home/home_view.dart';
@@ -25,8 +26,10 @@ GoRouter createRouter() {
       GoRoute(
         path: AppScreen.gamePlay.path,
         builder: (context, state) {
+          final characters = state.extra as List<CustomCharacter>;
+
           return ChangeNotifierProvider(
-            create: (_) => getIt<GamePlayViewModel>() ,
+            create: (_) => getIt<GamePlayViewModel>(param1: characters),
             child: GamePlayView(),
           );
         }

--- a/lib/presentation/router/service/router_service.dart
+++ b/lib/presentation/router/service/router_service.dart
@@ -1,4 +1,4 @@
 abstract interface class RouterService {
-  void navigateTo(String path);
+  void navigateTo(String path, {Object? extra});
   void goBack();
 }

--- a/lib/presentation/router/service/router_service_impl.dart
+++ b/lib/presentation/router/service/router_service_impl.dart
@@ -7,8 +7,8 @@ class RouterServiceImpl implements RouterService {
   RouterServiceImpl(this.router);
 
   @override
-  void navigateTo(String path) {
-    router.push(path);
+  void navigateTo(String path, {Object? extra}) {
+    router.push(path, extra: extra);
   }
 
   @override


### PR DESCRIPTION
- navigateTo 를 parameter도 함께 넘길 수 있도록 수정하였습니다.
  - nullable하게 parameter를 넘길 수 있게 하여 기존 navigateTo도 사용 가능합니다.
- GamePlayViewModel의 생성자 부분을 수정하였습니다
  - 받아온 캐릭터 리스트들을 state로 넘겨주면서 init하는 코드 생성하였습니다.

아래와 같이 사용할 수 있습니다.
(home view에서 몇 마리 + 이름들을 입력받아서 그걸 모델로 넘기는 방향)

`home_view_model.dart`
```dart  
case NavigateToGamePlay():
  // TODO: Pass parameter
  final dummyCharacters = [
    CustomCharacter(name: '말1', hexColor: 0xFFE57373),
    CustomCharacter(name: '말2', hexColor: 0xFF64B5F6),
    CustomCharacter(name: '말3', hexColor: 0xFF81C784),
  ];

  _routerService.navigateTo(AppScreen.gamePlay.path, extra: dummyCharacters);
```