### PR TITLE
feat/18: 캐릭터 이동 로직 개발

### DIFF
--- a/lib/domain/model/character/custom_character.dart
+++ b/lib/domain/model/character/custom_character.dart
@@ -1,9 +1,31 @@
 class CustomCharacter {
   final String name;
   final int hexColor; // TODO: 추후 필드 수정 예정
+  final double speed;
+  final double positionX;
+  final bool isFinished;
 
   const CustomCharacter({
     required this.name,
     required this.hexColor,
+    this.speed = 0.1,
+    this.positionX = 0,
+    this.isFinished = false,
   });
+
+  CustomCharacter copyWith({
+    String? name,
+    int? hexColor,
+    double? speed,
+    double? positionX,
+    bool? isFinished,
+  }) {
+    return CustomCharacter(
+      name: name ?? this.name,
+      hexColor: hexColor ?? this.hexColor,
+      speed: speed ?? this.speed,
+      positionX: positionX ?? this.positionX,
+      isFinished: isFinished ?? this.isFinished,
+    );
+  }
 }

--- a/lib/presentation/game_play/game_play_intent.dart
+++ b/lib/presentation/game_play/game_play_intent.dart
@@ -1,3 +1,11 @@
 sealed class GamePlayIntent {}
 
 class GoBackButtonTapped extends GamePlayIntent {}
+class TimerStartButtonTapped extends GamePlayIntent {}
+class UpdatePositionXWithSpeed extends GamePlayIntent {}
+class UpdateMaxDeviceWidthAndSafeArea extends GamePlayIntent {
+  final double maxDeviceWidth;
+  final double horizontalSafeArea;
+
+  UpdateMaxDeviceWidthAndSafeArea(this.maxDeviceWidth, this.horizontalSafeArea);
+}

--- a/lib/presentation/game_play/game_play_state.dart
+++ b/lib/presentation/game_play/game_play_state.dart
@@ -1,21 +1,25 @@
 import 'package:run_or_not/domain/model/character/custom_character.dart';
 
 class GamePlayState {
-  final int count;
-  final List<CustomCharacter> characters;
+  final List<CustomCharacter> characterList;
+  final double maxDeviceWidth;
+  final double horizontalSafeArea;
 
   GamePlayState({
-    this.count = 0,
-    required this.characters,
+    required this.characterList,
+    this.maxDeviceWidth = 376,
+    this.horizontalSafeArea = 0,
   });
 
   GamePlayState copyWith({
-    int? count,
-    List<CustomCharacter>? characters,
+    List<CustomCharacter>? characterList,
+    double? maxDeviceWidth,
+    double? horizontalSafeArea,
   }) {
     return GamePlayState(
-        count: count ?? this.count,
-        characters: characters ?? this.characters,
+      characterList: characterList ?? this.characterList,
+      maxDeviceWidth: maxDeviceWidth ?? this.maxDeviceWidth,
+      horizontalSafeArea: horizontalSafeArea ?? this.horizontalSafeArea,
     );
   }
 }

--- a/lib/presentation/game_play/game_play_view.dart
+++ b/lib/presentation/game_play/game_play_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/presentation/game_play/game_play_intent.dart';
 import 'package:run_or_not/presentation/game_play/game_play_view_model.dart';
 
@@ -9,37 +10,124 @@ class GamePlayView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final _viewModel = context.read<GamePlayViewModel>();
+    final _mediaQuery = MediaQuery.of(context);
+    final _maxWidth = _mediaQuery.size.width;
+    final _horizontalSafeArea = _mediaQuery.padding.left + _mediaQuery.padding.right;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _viewModel.send(UpdateMaxDeviceWidthAndSafeArea(_maxWidth, _horizontalSafeArea));
+    });
 
     return Scaffold(
-      // appBar: AppBar(title: const Text('GamePlay View')),
-      body: Column(
-        children: [
-          Center(
-            child: ElevatedButton(
-              onPressed: () {
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buttonRowView(
+              goBackButtonAction: () {
                 _viewModel.send(GoBackButtonTapped());
               },
-              child: const Text('Go Back'),
+              startButtonAction: () {
+                _viewModel.send(TimerStartButtonTapped());
+              },
             ),
-          ),
+            _CharacterListView(
+              characters: _viewModel.state.characterList,
+              maxWidth: _maxWidth,
+            )
+          ],
+        ),
+      ),
+    );
+  }
 
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.all(16),
-              children: _viewModel.state.characters.map((character) {
-                return Container(
-                  margin: const EdgeInsets.only(bottom: 12),
-                  padding: const EdgeInsets.all(16),
-                  color: Color(character.hexColor),
-                  child: Text(
-                    character.name,
-                    style: const TextStyle(fontSize: 18, color: Colors.white),
-                  ),
-                );
-              }).toList(),
+  Widget _buttonRowView({
+    required VoidCallback goBackButtonAction,
+    required VoidCallback startButtonAction,
+  }) {
+    return Row(
+      children: [
+        ElevatedButton(
+          onPressed: goBackButtonAction,
+          child: const Text('Go Back'),
+        ),
+        ElevatedButton(
+          onPressed: startButtonAction,
+          child: const Text('timer start'),
+        ),
+      ],
+    );
+  }
+}
+
+class _CharacterListView extends StatelessWidget {
+  final List<CustomCharacter> characters;
+  final double maxWidth;
+  final double _containerHeight = 44;
+  final double _avatarCircleSize = 40;
+
+  const _CharacterListView({
+    super.key,
+    required this.characters,
+    required this.maxWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: ListView(
+        children: characters.asMap().entries.map((entry) {
+          final index = entry.key;
+          final character = entry.value;
+
+          return Container(
+            height: _containerHeight,
+            decoration: BoxDecoration(
+              color: Color(character.hexColor),
+              borderRadius: BorderRadius.circular(8),
             ),
+            child: Stack(
+              children: [
+                Selector<GamePlayViewModel, double>(
+                  selector: (context, viewModel) => viewModel.state.characterList[index].positionX,
+                  builder: (context, positionX, _) {
+                    return _characterAvatarView(positionX);
+                  },
+                ),
+                _characterNameView(character.name),
+              ],
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _characterAvatarView(double positionX) {
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 100),
+      left: positionX.clamp(0, maxWidth),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(0, 2, 0, 2),
+        child: Container(
+          width: _avatarCircleSize,
+          height: _avatarCircleSize,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.black, width: 1),
           ),
-        ],
+        ),
+      ),
+    );
+  }
+
+  Widget _characterNameView(String name) {
+    return Positioned(
+      top: 2,
+      right: 10,
+      child: Text(
+        name,
+        style: const TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -25,10 +25,10 @@ GoRouter createRouter() {
       GoRoute(
         path: AppScreen.gamePlay.path,
         builder: (context, state) {
-          final characters = state.extra as List<(String, int)>;
+          final characterTuples = state.extra as List<(String, int)>;
 
           return ChangeNotifierProvider(
-            create: (_) => getIt<GamePlayViewModel>(param1: characters),
+            create: (_) => getIt<GamePlayViewModel>(param1: characterTuples),
             child: GamePlayView(),
           );
         }


### PR DESCRIPTION
feat/16이 merge가 되어있지 않아 target을 feat/16으로 설정하여 PR 올립니다.
추후 feat/16이 merge되면 target 브랜치 수정 예정입니다.

캐릭터가 달리는 로직을 개발하였습니다.
home_view_model.dart를 아래와 같이 바꾸시고 빌드하시면 테스트가 가능합니다.

```dart  
case NavigateToGamePlay():
  // TODO: Pass parameter
  final dummyCharactersTuples = [
    ('말1', 0xFFE57373),
    ('말2', 0xFF64B5F6),
    ('말3', 0xFF81C784),
  ];

  _routerService.navigateTo(AppScreen.gamePlay.path, extra: dummyCharactersTuples);
  break;
```
