### PR TITLE
feat/29: 랭킹 뷰 연결

### DIFF
--- a/lib/core/di/injector.dart
+++ b/lib/core/di/injector.dart
@@ -25,5 +25,10 @@ void setupDependencies() {
         getIt<GameUseCase>(),
     ),
   );
-  getIt.registerFactory(() => RankingViewModel());
+  getIt.registerFactoryParam<RankingViewModel, List<(String, int, int?)>, void>(
+    (characterTuples, _) => RankingViewModel(
+      getIt<RouterService>(),
+      characterTuples,
+    )
+  );
 }

--- a/lib/presentation/game_play/game_play_intent.dart
+++ b/lib/presentation/game_play/game_play_intent.dart
@@ -2,6 +2,7 @@ sealed class GamePlayIntent {}
 
 class GoBackButtonTapped extends GamePlayIntent {}
 class TimerStartButtonTapped extends GamePlayIntent {}
+class RankingButtonTapped extends GamePlayIntent {}
 class UpdatePositionXWithSpeed extends GamePlayIntent {}
 class UpdateMaxDeviceWidthAndSafeArea extends GamePlayIntent {
   final double maxDeviceWidth;

--- a/lib/presentation/game_play/game_play_state.dart
+++ b/lib/presentation/game_play/game_play_state.dart
@@ -4,6 +4,9 @@ class GamePlayState {
   final List<CustomCharacter> characterList;
   final double maxDeviceWidth;
   final double horizontalSafeArea;
+  bool get shouldShowRankingButton {
+    return characterList.every((character) => character.isFinished);
+  }
 
   GamePlayState({
     required this.characterList,
@@ -15,6 +18,7 @@ class GamePlayState {
     List<CustomCharacter>? characterList,
     double? maxDeviceWidth,
     double? horizontalSafeArea,
+    bool? isRankingButtonVisible,
   }) {
     return GamePlayState(
       characterList: characterList ?? this.characterList,

--- a/lib/presentation/game_play/game_play_view.dart
+++ b/lib/presentation/game_play/game_play_view.dart
@@ -29,6 +29,9 @@ class GamePlayView extends StatelessWidget {
               startButtonAction: () {
                 _viewModel.send(TimerStartButtonTapped());
               },
+              rankingButtonAction: () {
+                _viewModel.send(RankingButtonTapped());
+              },
             ),
             RaceLineListView(
               characters: _viewModel.state.characterList,
@@ -44,6 +47,7 @@ class GamePlayView extends StatelessWidget {
   Widget _buttonRowView({
     required VoidCallback goBackButtonAction,
     required VoidCallback startButtonAction,
+    required VoidCallback rankingButtonAction,
   }) {
     return Row(
       children: [
@@ -54,6 +58,17 @@ class GamePlayView extends StatelessWidget {
         ElevatedButton(
           onPressed: startButtonAction,
           child: const Text('timer start'),
+        ),
+        Selector<GamePlayViewModel, bool>(
+          selector: (context, viewModel) => viewModel.state.shouldShowRankingButton,
+          builder: (context, shouldShowRankingButton, _) {
+            return shouldShowRankingButton
+              ? ElevatedButton(
+                  onPressed: rankingButtonAction,
+                  child: const Text('Ranking View'),
+                )
+              : const SizedBox.shrink();
+          },
         ),
       ],
     );

--- a/lib/presentation/game_play/game_play_view_model.dart
+++ b/lib/presentation/game_play/game_play_view_model.dart
@@ -5,6 +5,7 @@ import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/domain/use_case/game/game_use_case.dart';
 import 'package:run_or_not/presentation/game_play/game_play_intent.dart';
 import 'package:run_or_not/presentation/game_play/game_play_state.dart';
+import 'package:run_or_not/presentation/router/app_screen.dart';
 import 'package:run_or_not/presentation/router/service/router_service.dart';
 
 class GamePlayViewModel extends ChangeNotifier {
@@ -54,6 +55,12 @@ class GamePlayViewModel extends ChangeNotifier {
     switch (intent) {
       case GoBackButtonTapped():
         _routerService.goBack();
+        break;
+      case RankingButtonTapped():
+        final charactersTuples = _state.characterList.map((character) {
+          return (character.name, character.hexColor, character.rank);
+        }).toList();
+        _routerService.navigateTo(AppScreen.ranking.path, extra: charactersTuples);
         break;
       case TimerStartButtonTapped():
         _timer?.cancel();

--- a/lib/presentation/ranking/ranking_state.dart
+++ b/lib/presentation/ranking/ranking_state.dart
@@ -1,14 +1,9 @@
-class RankingState {
-  final int count;
-  RankingState({
-    this.count = 0
-  });
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 
-  RankingState copyWith({
-    int? count
-  }) {
-    return RankingState(
-        count: count ?? this.count
-    );
-  }
+class RankingState {
+  final List<CustomCharacter> characterList;
+
+  RankingState({
+    required this.characterList,
+  });
 }

--- a/lib/presentation/ranking/ranking_view_model.dart
+++ b/lib/presentation/ranking/ranking_view_model.dart
@@ -1,10 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:run_or_not/domain/model/character/custom_character.dart';
 import 'package:run_or_not/presentation/ranking/ranking_intent.dart';
 import 'package:run_or_not/presentation/ranking/ranking_state.dart';
+import 'package:run_or_not/presentation/router/service/router_service.dart';
 
 class RankingViewModel extends ChangeNotifier {
-  RankingState _state = RankingState();
+  final RouterService _routerService;
+
+  RankingState _state;
   RankingState get state => _state;
+
+  RankingViewModel(
+      this._routerService,
+      List<(String, int, int?)> characterTuples,
+      ): _state = RankingState(
+      characterList: characterTuples.map((tuples) {
+
+      return CustomCharacter(
+        name: tuples.$1,
+        hexColor: tuples.$2,
+        rank: tuples.$3
+      );
+    }).toList(),
+  );
 
   void onIntent(RankingIntent intent) {
     switch (intent) {

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -36,8 +36,10 @@ GoRouter createRouter() {
       GoRoute(
         path: AppScreen.ranking.path,
         builder: (context, state) {
+          final characterTuples = state.extra as List<(String, int, int?)>;
+
           return ChangeNotifierProvider(
-            create: (_) => getIt<RankingViewModel>() ,
+            create: (_) => getIt<RankingViewModel>(param1: characterTuples) ,
             child: RankingView(),
           );
         }


### PR DESCRIPTION
GamePlayView -> Ranking View navigation 연결 작업입니다.

기존 뷰에서 모두 결승선에 들어오면 Ranking View로 갈 수 있는 버튼이 보이게 됩니다.
랭킹 뷰로 갈 때, 기존 Custom Model의 rank 정보와 이름 정보, 컬러 정보를 같이 가져가게 됩니다 (랭킹 뷰에서 그릴 UI에 필요)

ElevatedButton은 추후 커스텀 버튼으로 교체 예정입니다.